### PR TITLE
Settings table should be local

### DIFF
--- a/settings.lua
+++ b/settings.lua
@@ -1,5 +1,5 @@
 
-settings = {}
+local settings = {}
 
 local keys = {
 	up    = "up",


### PR DESCRIPTION
The settings table should be local or it will create a global table when required.
